### PR TITLE
Emoji groups and subgroups

### DIFF
--- a/src/cl-emoji.lisp
+++ b/src/cl-emoji.lisp
@@ -26,16 +26,17 @@ THE SOFTWARE.
 (defpackage #:cl-emoji
   (:use #:cl)
   (:nicknames #:emoji)
-  (:export code name annot +versions+ +default-version+))
+  (:export code name annot +versions+ *current-version*))
 (in-package #:cl-emoji)
 
 (defvar +versions+ '("4.0_release-30"
                      "5.0_release-31"))
-(defvar +default-version+ "4.0_release-30")
+(defvar *current-version* "4.0_release-30")
 
-(defun load-emoji (&optional (version *default-version*))
+(defun load-emoji ()
   (let ((emoji-list-path (asdf:system-relative-pathname
-                          :cl-emoji (pathname (format nil "data/emoji_~a.lisp" version)))))
+                          :cl-emoji (pathname (format nil "data/emoji_~a.lisp"
+                                                      *current-version*)))))
     (with-open-file (s emoji-list-path)
       (read s))))
 

--- a/src/cl-emoji.lisp
+++ b/src/cl-emoji.lisp
@@ -26,7 +26,7 @@ THE SOFTWARE.
 (defpackage #:cl-emoji
   (:use #:cl)
   (:nicknames #:emoji)
-  (:export code name annot +versions+ *current-version*))
+  (:export code name annot group subgroup +versions+ *current-version*))
 (in-package #:cl-emoji)
 
 (defvar +versions+ '("4.0_release-30"
@@ -50,5 +50,15 @@ THE SOFTWARE.
 
 (defun annot (annot)
   (loop for a in (load-emoji)
-     if (member annot (fourth a) :test #'string=)
-     collect a))
+        if (member annot (fourth a) :test #'string=)
+        collect a))
+
+(defun group (group)
+  (loop for g in (load-emoji)
+        if (string= group (fifth g))
+        collect g))
+
+(defun subgroup (subgroup)
+  (loop for sg in (load-emoji)
+        if (string= subgroup (sixth sg))
+        collect sg))

--- a/t/cl-emoji.lisp
+++ b/t/cl-emoji.lisp
@@ -11,11 +11,13 @@
 		    :cl-emoji (pathname (format nil "data/emoji_~a.lisp"
                                         cl-emoji::*current-version*))))
   (let ((emoji-list (read s)))
-    (plan (+ 3 (length emoji-list)))
+    (plan (+ 5 (length emoji-list)))
     (dolist (u emoji-list)
       (is (length u) 6))
     (is "😀" (emoji:code '("U+1F600")))
     (is "😁" (emoji:name "grinning face with smiling eyes"))
-    (ok (< 0 (length (emoji:annot "blue"))))))
+    (ok (< 0 (length (emoji:annot "blue"))))
+    (ok (< 0 (length (emoji:group "Smileys & People"))))
+    (ok (< 0 (length (emoji:subgroup "clothing"))))))
 
 (finalize)

--- a/t/cl-emoji.lisp
+++ b/t/cl-emoji.lisp
@@ -9,7 +9,7 @@
 
 (with-open-file (s (asdf:system-relative-pathname 
 		    :cl-emoji (pathname (format nil "data/emoji_~a.lisp"
-                                        cl-emoji::*default-version*))))
+                                        cl-emoji::*current-version*))))
   (let ((emoji-list (read s)))
     (plan (+ 3 (length emoji-list)))
     (dolist (u emoji-list)


### PR DESCRIPTION
**This pull request made over PR #2.**

This pull request do bellow:

- users can tell emoji version to cl-emoji through `*current-version*`
- cl-emoji select emoji by "groups" and "subgroups".

# Emoji version

If you tell emoji version to cl-emoji API, do like this (and I checked if path generated at API calling):

```lisp
CL-USRE> (trace format)
CL-USER> (cl-emoji:annot "grin")
  0: (FORMAT NIL "file ~A"
             "/path/to/cl-emoji/data/emoji_4.0_release-30.lisp")
  0: FORMAT returned
       "file /path/to/cl-emoji/data/emoji_4.0_release-30.lisp"
(("😀" ("U+1F600") "grinning face" ("face" "grin") "Smileys & People"
  "face-positive")
 ...)
CL-USER> (let ((cl-emoji:*current-version* (second cl-emoji:+versions+)))
           (cl-emoji:annot "grin"))
  0: (FORMAT NIL "file ~A"
             "/path/to/cl-emoji/data/emoji_5.0_release-31.lisp")
  0: FORMAT returned
       "file /path/to/cl-emoji/data/emoji_5.0_release-31.lisp"
(("😀" ("U+1F600") "grinning face" ("face" "grin") "Smileys & People"
  "face-positive")
 ...)
```

# Groups and Subgroups

Those are appears in [Full Emoji Data](http://www.unicode.org/emoji/charts-beta/full-emoji-list.html), for instance `Smileys & People` is a group and `face-positive` is a subgroup.

You can get emoji by group name and subgroup name with API `cl-emoji:group` and `cl-emoji:subgroup`.