### PR TITLE
Listing annotations, groups and subgroups

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -44,6 +44,25 @@ CL-USER> (let ((cl-emoji:*current-version* (second cl-emoji:+versions+)))
  ...)
 ```
 
+According to **PR #xx**, we can list annotations, groups and subgroups.
+Cause of this now we can know what is keyword when searching with `emoji:annot`.
+
+```lisp
+CL-USER> (emoji:list-subgroups)
+("face-positive" "face-neutral" "face-negative" "face-role" "face-sick"
+ "creature-face" "cat-face" "monkey-face" "person" "person-role"
+ ...)
+CL-USER> (emoji:subgroup (first (emoji:list-subgroups)))
+(("😀" ("U+1F600") "grinning face" ("face" "grin") "Smileys & People"
+  "face-positive")
+ ("😁" ("U+1F601") "grinning face with smiling eyes"
+  ("eye" "face" "grin" "smile") "Smileys & People" "face-positive")
+ ("😂" ("U+1F602") "face with tears of joy" ("face" "joy" "laugh" "tear")
+  "Smileys & People" "face-positive")
+ ("🤣" ("U+1F923") "rolling on the floor laughing"
+ ...))
+```
+
 ### :smile: Groups and Subgroups
 
 Those are appears in [Full Emoji Data](http://www.unicode.org/emoji/charts-beta/full-emoji-list.html), for instance `Smileys & People` is a group and `face-positive` is a subgroup.

--- a/src/cl-emoji.lisp
+++ b/src/cl-emoji.lisp
@@ -26,7 +26,9 @@ THE SOFTWARE.
 (defpackage #:cl-emoji
   (:use #:cl)
   (:nicknames #:emoji)
-  (:export code name annot group subgroup +versions+ *current-version*))
+  (:export code name annot group subgroup
+           list-annots list-groups list-subgroups
+           +versions+ *current-version*))
 (in-package #:cl-emoji)
 
 (defvar +versions+ '("4.0_release-30"
@@ -62,3 +64,19 @@ THE SOFTWARE.
   (loop for sg in (load-emoji)
         if (string= subgroup (sixth sg))
         collect sg))
+
+(defun list-annots ()
+  (loop
+     for annots in (mapcar #'fourth (load-emoji))
+     with annotations = nil
+     finally (return-from list-annots annotations)
+     when annots
+     do (loop
+           for a in annots
+           do (setf annotations (adjoin a annotations :test #'string=)))))
+
+(defun list-groups ()
+  (remove-duplicates (mapcar #'fifth (load-emoji)) :test #'string=))
+
+(defun list-subgroups ()
+  (remove-duplicates (mapcar #'sixth (load-emoji)) :test #'string=))

--- a/t/cl-emoji.lisp
+++ b/t/cl-emoji.lisp
@@ -11,13 +11,16 @@
 		    :cl-emoji (pathname (format nil "data/emoji_~a.lisp"
                                         cl-emoji::*current-version*))))
   (let ((emoji-list (read s)))
-    (plan (+ 5 (length emoji-list)))
+    (plan (+ 8 (length emoji-list)))
     (dolist (u emoji-list)
       (is (length u) 6))
     (is "😀" (emoji:code '("U+1F600")))
     (is "😁" (emoji:name "grinning face with smiling eyes"))
     (ok (< 0 (length (emoji:annot "blue"))))
     (ok (< 0 (length (emoji:group "Smileys & People"))))
-    (ok (< 0 (length (emoji:subgroup "clothing"))))))
+    (ok (< 0 (length (emoji:subgroup "clothing"))))
+    (ok (< 0 (length (emoji:list-annots))))
+    (ok (< 0 (length (emoji:list-groups))))
+    (ok (< 0 (length (emoji:list-subgroups))))))
 
 (finalize)


### PR DESCRIPTION
We can't know what the keyword when searching with `emoji:annot`, `emoji:group` and `emoji:subgroup`, before this PR. Sadness. :cry:
But this PR make we know what keyword is. :grin:

This PR adds three APIs:

- `emoji:list-annots`: list all annotations
- `emoji:list-groups`: list all groups
` `emoji:list-subgroups`: list all subgroups

For instance, we can use `emoji:subgroups` like this:

```lisp
CL-USER> (emoji:list-subgroups)
("face-positive" "face-neutral" "face-negative" "face-role" "face-sick"
 "creature-face" "cat-face" "monkey-face" "person" "person-role"
 ...)
CL-USER> (emoji:subgroup (first (emoji:list-subgroups)))
(("😀" ("U+1F600") "grinning face" ("face" "grin") "Smileys & People"
  "face-positive")
 ("😁" ("U+1F601") "grinning face with smiling eyes"
  ("eye" "face" "grin" "smile") "Smileys & People" "face-positive")
 ...))
```