### PR TITLE
Following Unicode 10.0 by default

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3,6 +3,8 @@ cl-emoji provides the Unicode emoji characters
 
 :smile: :heart_eyes: :scream: :alien: :fire: :zzz: :hand:
 
+cl-emoji is able to treat Emoji 5.0 defined in Unicode 10.0! (ex. UFO; https://emojipedia.org/flying-saucer/)
+
 ## :boom: Usage
 
 ```lisp

--- a/src/cl-emoji.lisp
+++ b/src/cl-emoji.lisp
@@ -42,7 +42,7 @@ THE SOFTWARE.
 
 (defvar +versions+ '("4.0_release-30"
                      "5.0_release-31"))
-(defvar *current-version* "4.0_release-30")
+(defvar *current-version* "5.0_release-31")
 
 (defun load-emoji ()
   (let ((emoji-list-path (asdf:system-relative-pathname


### PR DESCRIPTION
On June 20th, Unicode 10.0 released! [We can use many newly emoji!](http://www.unicode.org/emoji/charts/emoji-released.html) Yappie! :tada:

Now, I think cl-emoji's default emoji version should follow Unicode 10.0. Supported Emoji version in Unicode 10.0 is Emoji 5.0 and CLDR 31 (CLDR defines _annotations_). For details, see the URL http://www.unicode.org/reports/tr51/tr51-12.html.

In this PR I updated default emoji version in `src/cl-emoji.lisp` and README to notice that **cl-emoji supports Unicode 10.0**. 